### PR TITLE
Exclude node_modules from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules


### PR DESCRIPTION
Updating the gitignore with the node modules directory so that we do not commit package binaries.